### PR TITLE
ci: add TestGlance test reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     name: Test
@@ -41,6 +45,13 @@ jobs:
 
     - name: Run tests
       run: sbt clean coverage test coverageReport
+
+    - name: TestGlance
+      if: always() && matrix.java == '17'
+      uses: testglance/action@257d6825154548f970e85566f7c19a48eb7a2ea3 # v1
+      with:
+        github-token: ${{ github.token }}
+        report-path: '**/target/test-reports/TEST-*.xml'
 
     - name: Upload coverage reports to Codecov
       if: matrix.java == '17'


### PR DESCRIPTION
Adds [TestGlance](https://github.com/testglance/action) to the CI workflow so each run publishes a test summary, a PR comment, and a check run.

## Change
- **ci.yml** — add a `TestGlance` step after `Run tests`, gated to `matrix.java == '17'` so the 3-way Java matrix (17/21/24) posts a single result. Adds `pull-requests: write` permission for the PR comment.

No build change is needed: specs2 already writes JUnit XML to `target/test-reports/TEST-*.xml` on `sbt test` (also under `sbt clean coverage test coverageReport`), so the step just points `report-path` there.

## Mode
Local-only (no API key). The action renders a CI summary + PR comment + check run and never fails CI by design.

## Verified locally
`sbt clean coverage test coverageReport` produces 12 `target/test-reports/TEST-*.xml` files (66/66 passing), and the action's JUnit parser reads them correctly (total=66, passed=66).