### PR TITLE
Configure Renovate with best-practices preset and CI-gated automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    ":dependencyDashboard"
+  ],
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates once required CI checks pass",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Keep major updates as manual PRs for human review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
## What

Upgrades the Renovate configuration from bare `config:recommended` to an industry-standard setup with automerge.

## Changes to `renovate.json`
- Extend **`config:best-practices`** - Renovate's officially recommended preset (GitHub Action digest pinning for supply-chain safety, config migration PRs, and other sensible defaults).
- **Automerge** `minor` / `patch` / `pin` / `digest` updates via GitHub's native auto-merge (`platformAutomerge: true`), **gated by the required branch-protection status checks** - a bad update simply won't merge because CI stays red.
- **Major** updates remain manual PRs for human review.

## Why
Trivial dependency bumps (Scala patch, sbt plugins, GitHub Actions) were each becoming a manual chore. With automerge gated by the existing CI matrix (compile + tests + scalafmt), green low-risk updates now merge themselves, while anything that breaks the build stays open for a human.

## Related repo settings enabled alongside this
- `Allow auto-merge` (required for `platformAutomerge`)
- `Automatically delete head branches` after merge
- Branch protection `strict` (require-up-to-date) turned **off**, so queued PRs don't block each other; required status checks still enforced.

Config validated with `renovate-config-validator`.