### PR TITLE
build: migrate to sbt 2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-sbt-
 
     - name: Run tests
-      run: sbt ++${{ matrix.scala }} clean coverage test coverageReport
+      run: sbt "++${{ matrix.scala }}; clean; coverage; test; coverageReport"
 
     - name: TestGlance
       if: always() && matrix.java == '25'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,13 @@ jobs:
       uses: testglance/action@257d6825154548f970e85566f7c19a48eb7a2ea3 # v1
       with:
         github-token: ${{ github.token }}
-        report-path: '**/target/test-reports/TEST-*.xml'
+        report-path: '**/test-reports/TEST-*.xml'
 
     - name: Upload coverage reports to Codecov
       if: matrix.java == '17'
       uses: codecov/codecov-action@v7
       with:
-        files: ./target/scala-3.3.8/scoverage-report/scoverage.xml
+        files: ./target/out/jvm/scala-3.8.4/coding-interview-questions/scoverage-report/scoverage.xml
         fail_ci_if_error: false
         verbose: true
       env:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=2.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,6 @@
 logLevel := Level.Warn
 
-resolvers += Classpaths.sbtPluginReleases
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
 


### PR DESCRIPTION
Completes the sbt **1.x → 2.x** major upgrade. Supersedes #89, which only bumps `project/build.properties` - that change alone **breaks the build**, because sbt 2.0's build language is Scala 3 and every plugin must be cross-published for sbt 2.0.

## Changes
- **sbt 1.12.13 → 2.0.1** (`project/build.properties`)
- **Drop `sbt-coveralls`**: no sbt 2.0 cross-build exists yet, and it was only invoked by the retired `.travis.yml`. Active CI uses scoverage + Codecov, never the `coveralls` task. Also removed the defunct `Classpaths.sbtPluginReleases` resolver.
- **Kept as-is** (all sbt-2.0 compatible via `_sbt2_3` artifacts): `sbt-scoverage` 2.4.4, `sbt-scalafmt` 2.6.1, `sbt-ci-release` 1.12.0.
- **CI path fixes** for sbt 2.0's new target layout `target/out/jvm/scala-3.8.4/…`: the Codecov `scoverage.xml` path and the TestGlance `test-reports` glob.

## Verification (local, sbt 2.0.1)
- `sbt clean coverage test coverageReport` → **66 tests, 0 failures, 98.66% statement coverage** ✅
- `sbt scalafmtCheckAll` ✅
- `sbt compile` ✅

JDK: sbt 2.0 requires ≥ 17; CI matrix (17/21/24) is fine.

## Note (out of scope)
Pre-existing: the CI matrix declares `scala: [3.3.8]` but `build.sbt` hardcodes `scalaVersion := "3.8.4"` - the matrix value is unused. Worth reconciling in a separate change.

Closes #89