### PR TITLE
chore: reconcile Scala/Java versions and fix CI coverage path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [17, 21, 24]
+        java: [25]
         scala: [3.3.8]
 
     steps:
@@ -44,26 +44,26 @@ jobs:
           ${{ runner.os }}-sbt-
 
     - name: Run tests
-      run: sbt clean coverage test coverageReport
+      run: sbt ++${{ matrix.scala }} clean coverage test coverageReport
 
     - name: TestGlance
-      if: always() && matrix.java == '17'
+      if: always() && matrix.java == '25'
       uses: testglance/action@5df28a307a187d790e347600464dd04cf42a12ba # v1
       with:
         github-token: ${{ github.token }}
         report-path: '**/target/test-reports/TEST-*.xml'
 
     - name: Upload coverage reports to Codecov
-      if: matrix.java == '17'
+      if: matrix.java == '25'
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
-        files: ./target/scala-3.3.8/scoverage-report/scoverage.xml
+        files: ./target/scala-${{ matrix.scala }}/scoverage-report/scoverage.xml
         fail_ci_if_error: false
         verbose: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Check formatting
-      if: matrix.java == '17'
+      if: matrix.java == '25'
       run: sbt scalafmtCheckAll
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This is a Scala coding interview questions repository with solutions and compreh
 ## Build System
 
 - **Build Tool**: sbt 1.11.5 (Scala Build Tool)
-- **Scala Version**: 3.3.6 LTS
+- **Scala Version**: 3.3.8 LTS
 - **Test Framework**: Specs2 4.20.8 with ScalaCheck 1.19.0 for property-based testing
 
 ## Common Commands
@@ -74,7 +74,7 @@ The project uses a trait-based testing approach:
 ## CI/CD
 
 - GitHub Actions workflow runs on all pull requests to master
-- Tests run on Java 17, 21, and 24 with Scala 3.3.6
+- Tests run on Java 25 (latest LTS) with Scala 3.3.8
 - Code coverage reports are uploaded to Codecov
 - Scalafmt formatting checks ensure consistent code style
 - SBT dependencies are cached for faster builds

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "coding-interview-questions"
 
 version := "2.0.0"
 
-scalaVersion := "3.8.4"
+scalaVersion := "3.3.8"
 
 libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "5.9.1" % Test,


### PR DESCRIPTION
## Summary
Reconciles three drifting Scala versions (build.sbt `3.8.4`, CI matrix `3.3.8`,
CLAUDE.md `3.3.6`) onto the Scala 3.3.8 LTS line, fixes a silently-broken
Codecov upload, and trims the Java matrix to LTS-only.

## Changes
- **build.sbt**: `scalaVersion` `3.8.4` (Scala Next line) -> `3.3.8` (LTS). Verified compiles.
- **ci.yml**: wire `++${{ matrix.scala }}` into the test run so the matrix actually drives the build (was inert).
- **ci.yml**: derive the scoverage upload path from `${{ matrix.scala }}` — it was hardcoded to `scala-3.3.8` while the build produced `scala-3.8.4`, so Codecov received nothing.
- **ci.yml**: Java matrix `[17, 21, 24]` -> `[25]` (LTS-only); moved the gated coverage/TestGlance/scalafmt steps from `== '17'` to `== '25'`.
- **CLAUDE.md**: sync documented Scala (3.3.8) and Java (25) versions.

## Notes / tradeoff
Testing only Java 25 means regressions specific to Java 17/21 won't be caught.
Acceptable for a pure-algorithms repo, but flagging it explicitly.

## Test plan
- [ ] CI green on Java 25 / Scala 3.3.8
- [ ] Codecov report uploads successfully (non-empty coverage)
- [ ] `sbt ++3.3.8 clean coverage test coverageReport` passes locally
